### PR TITLE
Missing lombok config with parent

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+import target/configs/powsybl-build-tools.jar!powsybl-build-tools/lombok.config


### PR DESCRIPTION
Lombok config has been forgotten when migrating parent pom.
Detected while working on #9.